### PR TITLE
Add support for --application-package-names option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,13 @@ application. These will be used to help categorise your import
 statements into the correct groups. Note that relative imports are
 always considered local.
 
+You will want to set the ``application-package-names`` option to a
+comma separated list of names that should be considered local to your
+company or organisation, but which is obtained using some sort of
+package manager like Pip, Apt, or Yum.  Typically, code representing the
+values listed in this option is located in a different repository than
+the code being developed.
+
 ``import-order-style`` controls what style the plugin follows
 (``cryptography`` is the default):
 
@@ -54,8 +61,9 @@ Conditional imports in module scope will also be ignored.
 
 Classification of an imported module is achieved by checking the
 module against a stdlib list and then if there is no match against the
-``application-import-names`` list. Only if neither of the lists
-contain the imported module will it be classified as third party.
+``application-import-names`` and ``application-package-names`` lists.
+Only if none of these three lists contain the imported module will it be
+classified as third party.
 
 ``I201`` only checks that groups of imports are not consecutive and only
 takes into account the first line of each import statement. This means

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -17,8 +17,9 @@ DEFAULT_IMPORT_ORDER_STYLE = 'cryptography'
 IMPORT_FUTURE = 0
 IMPORT_STDLIB = 10
 IMPORT_3RD_PARTY = 20
-IMPORT_APP = 30
-IMPORT_APP_RELATIVE = 40
+IMPORT_APP_PACKAGE = 30
+IMPORT_APP = 40
+IMPORT_APP_RELATIVE = 50
 IMPORT_MIXED = -1
 
 ClassifiedImport = namedtuple(
@@ -38,9 +39,10 @@ def root_package_name(name):
 
 class ImportVisitor(ast.NodeVisitor):
 
-    def __init__(self, application_import_names):
+    def __init__(self, application_import_names, application_package_names):
         self.imports = []
         self.application_import_names = application_import_names
+        self.application_package_names = application_package_names
 
     def visit_Import(self, node):  # noqa
         if node.col_offset == 0:
@@ -78,6 +80,8 @@ class ImportVisitor(ast.NodeVisitor):
             return IMPORT_FUTURE
         elif package in self.application_import_names:
             return IMPORT_APP
+        elif package in self.application_package_names:
+            return IMPORT_APP_PACKAGE
         elif package in STDLIB_NAMES:
             return IMPORT_STDLIB
         else:

--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -38,6 +38,7 @@ class ImportOrderChecker(object):
 
         visitor = self.visitor_class(
             self.options.get('application_import_names', []),
+            self.options.get('application_package_names', []),
         )
         visitor.visit(self.tree)
 

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -25,7 +25,17 @@ class Linter(ImportOrderChecker):
             default="",
             action="store",
             type="string",
-            help="Import names to consider as application specific",
+            help="Import names to consider as application-specific",
+            parse_from_config=True,
+            comma_separated_list=True,
+        )
+        register_opt(
+            parser,
+            "--application-package-names",
+            default="",
+            action="store",
+            type="string",
+            help="Package names to consider as company-specific",
             parse_from_config=True,
             comma_separated_list=True,
         )
@@ -48,8 +58,13 @@ class Linter(ImportOrderChecker):
         if not isinstance(names, list):
             names = options.application_import_names.split(",")
 
+        pkg_names = options.application_package_names
+        if not isinstance(pkg_names, list):
+            pkg_names = options.application_package_names.split(",")
+
         optdict = dict(
             application_import_names=[n.strip() for n in names],
+            application_package_names=[p.strip() for p in pkg_names],
             import_order_style=options.import_order_style,
         )
 

--- a/tests/test_cases/complete_bad_order_with_application_package_names.py
+++ b/tests/test_cases/complete_bad_order_with_application_package_names.py
@@ -1,0 +1,6 @@
+import ast
+
+import a_third_party_package
+import local_package # I201
+
+from . import A

--- a/tests/test_cases/complete_with_application_package_names.py
+++ b/tests/test_cases/complete_with_application_package_names.py
@@ -1,0 +1,7 @@
+import ast
+
+import z_third_party_package
+
+import local_package
+
+from . import A

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -30,6 +30,26 @@ def load_test_cases():
 
     return test_cases
 
+def process_args_and_filename(argv, filename):
+    base_path = os.path.dirname(__file__)
+    test_case_path = os.path.join(base_path, "test_cases")
+    fullpath = os.path.join(test_case_path, filename)
+    data = open(fullpath).read()
+    tree = ast.parse(data, fullpath)
+
+    parser = pycodestyle.get_parser('', '')
+    Linter.add_options(parser)
+    options, args = parser.parse_args(argv)
+    Linter.parse_options(options)
+
+    checker = Linter(tree, fullpath)
+    codes = []
+    messages = []
+    for lineno, col_offset, msg, instance in checker.run():
+        code, message = msg.split(" ", 1)
+        codes.append(code)
+        messages.append(message)
+    return (codes, messages)
 
 @pytest.mark.parametrize(
     "tree, filename, expected_codes, expected_messages",
@@ -37,54 +57,26 @@ def load_test_cases():
 )
 def test_expected_error(tree, filename, expected_codes, expected_messages):
     argv = [
-        "--application-import-names=flake8_import_order,tests"
+        "--application-import-names=flake8_import_order,tests",
+        "--application-package-names=local_package",
     ]
 
     for style in ['google', 'smarkets', 'pep8']:
         if style in filename:
             argv.append('--import-order-style=' + style)
             break
-
-    parser = pycodestyle.get_parser('', '')
-    Linter.add_options(parser)
-    options, args = parser.parse_args(argv)
-    Linter.parse_options(options)
-
-    checker = Linter(tree, filename)
-    codes = []
-    messages = []
-    for lineno, col_offset, msg, instance in checker.run():
-        code, message = msg.split(" ", 1)
-        codes.append(code)
-        messages.append(message)
+    codes, messages = process_args_and_filename(argv, filename)
     assert codes == expected_codes
     assert set(messages) >= set(expected_messages)
 
 
 def test_I101_default_style():
-    base_path = os.path.dirname(__file__)
-    test_case_path = os.path.join(base_path, "test_cases")
-    fullpath = os.path.join(test_case_path, "bad_order.py")
-    data = open(fullpath).read()
-    tree = ast.parse(data, fullpath)
-
     argv = [
         "--application-import-names=flake8_import_order,tests",
 #        "--import-order-style=google",
     ]
-
-    parser = pycodestyle.get_parser('', '')
-    Linter.add_options(parser)
-    options, args = parser.parse_args(argv)
-    Linter.parse_options(options)
-
-    checker = Linter(tree, fullpath)
-    codes = []
-    messages = []
-    for lineno, col_offset, msg, instance in checker.run():
-        code, message = msg.split(" ", 1)
-        codes.append(code)
-        messages.append(message)
+    filename = "bad_order.py"
+    codes, messages = process_args_and_filename(argv, filename)
     assert codes == ["I101"]
     assert messages == [
         "Imported names are in the wrong order. Should be A, D, c"
@@ -92,29 +84,13 @@ def test_I101_default_style():
 
 
 def test_I101_google_style():
-    base_path = os.path.dirname(__file__)
-    test_case_path = os.path.join(base_path, "test_cases")
-    fullpath = os.path.join(test_case_path, "bad_order_google.py")
-    data = open(fullpath).read()
-    tree = ast.parse(data, fullpath)
-
     argv = [
         "--application-import-names=flake8_import_order,tests",
         "--import-order-style=google",
     ]
+    filename = "bad_order_google.py"
+    codes, messages = process_args_and_filename(argv, filename)
 
-    parser = pycodestyle.get_parser('', '')
-    Linter.add_options(parser)
-    options, args = parser.parse_args(argv)
-    Linter.parse_options(options)
-
-    checker = Linter(tree, fullpath)
-    codes = []
-    messages = []
-    for lineno, col_offset, msg, instance in checker.run():
-        code, message = msg.split(" ", 1)
-        codes.append(code)
-        messages.append(message)
     assert codes == ["I101"]
     assert messages == [
         "Imported names are in the wrong order. Should be A, c, D"

--- a/tests/test_pylama_linter.py
+++ b/tests/test_pylama_linter.py
@@ -40,7 +40,8 @@ def test_expected_error(filename, expected_codes, expected_messages):
     messages = []
 
     options = {
-        "application_import_names": ["flake8_import_order", "tests"]
+        "application_import_names": ["flake8_import_order", "tests"],
+        "application_package_names": ["local_package"],
     }
 
     for style in ['google', 'smarkets', 'pep8']:


### PR DESCRIPTION
The --application-package-names flag allows for code which is owned by
the developer's company, but which is not local to the curent repository or
codebase, to be ranked higher in import order checking than local
imports, but lower than third-party imports.
